### PR TITLE
Implemented feature to only download new files (#1)

### DIFF
--- a/studip-sync.py
+++ b/studip-sync.py
@@ -6,10 +6,25 @@ import requests
 import zipfile
 from bs4 import BeautifulSoup
 import threading
+from dataclasses import dataclass
+from glob import glob
+
+@dataclass
+class FileInfo:
+    """A file from StudIP.
+    
+    Attributes:
+        file_id: The Stud.IP internal file ID.
+        name: The filename.
+        path: A list of the parent folders of this file."""
+    file_id: str
+    name: str
+    path: list[str]
+
 
 login_url = 'https://elearning.uni-bremen.de/index.php?again=yes'
 course_url = 'https://elearning.uni-bremen.de/dispatch.php/course/files?cid='
-newest_url = 'https://elearning.uni-bremen.de/dispatch.php/course/files/newest_files?cid='
+files_flat_url = 'https://elearning.uni-bremen.de/dispatch.php/course/files/flat?cid='
 
 cfg = configparser.ConfigParser()
 script_path = os.path.dirname(os.path.abspath(__file__))
@@ -18,7 +33,7 @@ try:
     user = cfg.get('settings', 'user')
     password = cfg.get('settings', 'password')
     path = cfg.get('settings', 'data_folder')
-    new_only = cfg.get('settings', 'new_only')
+    new_only = cfg.getboolean('settings', 'new_only')
 except Exception as e:
     print('error parsing config file')
     print(e)
@@ -55,32 +70,76 @@ def getfiles(course):
 
     print(course[0], ': extracting post parameters')
     security_token = parsed_content.find('input', attrs={'type': 'hidden', 'name': 'security_token'}).attrs['value']
-    parent_folder_id = parsed_content.find('input', attrs={'type': 'hidden', 'name': 'parent_folder_id'}).attrs['value']
-    post_url = parsed_content.find('form', attrs={'method': 'post', 'action': re.compile(
+    
+    print(f'{course[0]} : fetching file information')
+
+    file_infos: list[FileInfo] = []
+
+    def get_files_recursively(url: str, path: list[str] = []):
+        files_page = BeautifulSoup(session.get(url, data={
+            'security_token': security_token,
+        }).content, 'html.parser')
+
+        tbody_subfolders = files_page.find('tbody', attrs={'class': 'subfolders'})
+
+        if tbody_subfolders != None:
+            for subfolder_row in tbody_subfolders.find_all('tr'):
+                if subfolder_row.has_attr('class') and 'empty' in subfolder_row['class']:
+                    continue
+                    
+                anchor = subfolder_row.find_all('td')[2].find('a')
+
+                new_path = path.copy()
+                new_path.append(anchor.string.strip())
+
+                get_files_recursively(anchor['href'], new_path)
+
+        tbody_files = files_page.find('tbody', attrs={'class': 'files'})
+
+        if tbody_files != None:
+            for file_row in tbody_files.find_all('tr', id=re.compile(r'^fileref_')):
+                file_id = re.match(r'^fileref_(.+)', file_row['id']).group(1)
+                filename = file_row.find_all('td')[2]['data-sort-value']
+
+                if (not new_only) or (not os.path.exists(os.path.join(file_target, *path, filename))):
+                    file_infos.append(FileInfo(file_id, filename, path))
+
+
+    get_files_recursively(download_url)
+
+    print(f'{course[0]} : found {len(file_infos)} new file(s)')
+
+    if len(file_infos) == 0:
+        return
+
+    
+    files_flat_content = session.get(files_flat_url + course[1], data = {
+        'security_token': security_token
+    }).content
+
+    files_flat_page = BeautifulSoup(files_flat_content, 'html.parser')
+    
+    post_url = files_flat_page.find('form', attrs={'method': 'post', 'action': re.compile(
         '^https://elearning.uni-bremen.de/dispatch.php/file/bulk/')}).attrs['action']
-    checkboxes = parsed_content.find_all('input',
-                                         attrs={'class': 'studip-checkbox', 'type': 'checkbox', 'name': 'ids[]',
-                                                'id': re.compile('^file_checkbox_')})
-    ids = list(map(lambda c: c.attrs['value'], checkboxes))
 
     token = {}
     token['security_token'] = security_token
-    token['parent_folder_id'] = parent_folder_id
-    token['ids[]'] = ids
+    token['ids[]'] = [file.file_id for file in file_infos]
     token['download'] = ''
-
-    if (new_only == 'yes'):
-        post_url = newest_url + course[1]
-        token = {}
 
     print(course[0], ': requesting download')
     r = session.post(post_url, data=token)
     if (r.status_code != 200):
         print(course[0], ': request failed')
 
-    z = zipfile.ZipFile(io.BytesIO(r.content))
-    print(course[0], ': extracting zip')
-    z.extractall(file_target)
+    # if only one file is downloaded, it will not be a zip file
+    if len(file_infos) > 1:
+        z = zipfile.ZipFile(io.BytesIO(r.content))
+        print(course[0], ': extracting zip')
+        z.extractall(file_target)
+    else:
+        with open(os.path.join(file_target, file_infos[0].name), 'wb') as file:
+            file.write(r.content)
 
     for root, dirs, files in os.walk(file_target):
         for file in files:
@@ -89,9 +148,24 @@ def getfiles(course):
                 continue
 
             filename = os.path.join(root, file)
-            os.replace(filename, os.path.join(root, re.sub('^[+[0-9]+]_', '', file)))
+            os.replace(filename, os.path.join(root, re.sub('^\[\d+\]_', '', file)))
 
     print(course[0], ': cleaned files')
+
+    print(f'{course[0]} : moving files into subfolders')
+
+    for fileinfo in file_infos:
+        # create the directories if they don't exist
+        os.makedirs(os.path.join(file_target, *fileinfo.path), exist_ok=True)
+
+        # move the files into their subfolders
+        try:
+            os.rename(
+                os.path.join(file_target, fileinfo.name),
+                os.path.join(file_target, *fileinfo.path, fileinfo.name)
+            )
+        except:
+            print(f'{course[0]} : failed to move file {fileinfo.name}, skipping file')
 
 for course in cfg.items('courses'):
     threading.Thread(target=getfiles, args=(course,)).start()


### PR DESCRIPTION
(Issue #1)

Downloading only new files works now.

The script has to fetch all the file information in order to compare it with the local files. This can take a moment because the script fetches each subdirectory recursively by loading the page for each subfolder.

I also fixed a bug where if you only download one file, only that file will be downloaded instead of a zip file. This case was not handled before.

This is what the output looks like when deleting a file and running the script again:

```shell
studip-sync-files-fork> rm 'C:\Users\Merlin\Documents\StudIP\m2\3. Skript zur Vorlesung\210607_TH_Skript-Mathematik-2_v3.pdf'
studip-sync-files-fork> py .\studip-sync.py
```

```text
Config Loaded!
starting session
no value attribute
login successful
finding course m2 ( d581d22a0ac281146020ab1c74d4f58f )
finding course ti1 ( ec9bab1eb846a248ea06fd69d3017f2f )
finding course dbm ( 876b0a670e8c563bb95bce37fe5841f6 )
finding course pi2 ( 3ede5f1b873f61c4be7a3b16897d30d5 )
m2 : extracting post parameters
m2 : fetching file information
pi2 : extracting post parameters
pi2 : fetching file information
dbm : extracting post parameters
dbm : fetching file information
ti1 : extracting post parameters
ti1 : fetching file information
pi2 : found 0 new file(s)
dbm : found 0 new file(s)
ti1 : found 0 new file(s)
m2 : found 1 new file(s)
m2 : requesting download
m2 : cleaned files
m2 : moving files into subfolders
```